### PR TITLE
Update footer with centered logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,11 +229,22 @@
             display: block;
         }
 
-        .copyright {
+        footer {
             text-align: center;
-            color: #666666;
-            font-size: 12px;
-            margin-top: 20px;
+            padding: 40px 0;
+            background-color: #f9f9f9;
+        }
+
+        .footer-logo {
+            width: 50px;
+            height: 50px;
+            display: block;
+            margin: 0 auto 10px;
+        }
+
+        .footer-text {
+            color: #555;
+            font-size: 0.9em;
         }
     </style>
 </head>
@@ -272,7 +283,6 @@
         <button class="button download-button" id="downloadButton">MP3をダウンロード</button>
 
         <div class="error-message" id="errorMessage"></div>
-        <p class="copyright">SOOOP の著作権です。</p>
     </div>
 
     <!-- lamejs library for MP3 encoding -->
@@ -610,10 +620,9 @@
         });
 </script>
 
-    <footer style="text-align: center; padding: 40px 0; background-color: #f9f9f9;">
-        <p style="color: #555; font-size: 0.9em;">
-            © 2025 SOOOP. All rights reserved.
-        </p>
+    <footer>
+        <img class="footer-logo" src="https://via.placeholder.com/50" alt="SOOOP logo">
+        <p class="footer-text">© 2025 SOOOP. All rights reserved.</p>
     </footer>
 
 </body>


### PR DESCRIPTION
## Summary
- style footer section
- remove in-app copyright text
- add placeholder logo and copyright info at bottom center

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849958e7c9c832d8f4cd1475185f9ed